### PR TITLE
Classmap instead of psr-4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,6 @@
   },
   "autoload": {
     "files": ["src/protocolbuffers.inc.php"],
-    "psr-4": {
-      "POGOProtos\\": "src/POGOProtos"
-    }
+    "classmap": ["src/POGOProtos"]
   }
 }


### PR DESCRIPTION
I don't think you can currently use PSR-4, because of the *.proto.php names.

Better would probably be to just use psr-4 naming, but not sure if that's possible.
Also, if you move the git submodules outside the /src directory (you don't actually need them to use this, right?), you could also just classmap entire src dir and drop  the files autoload.
