### PR TITLE
When read_bytes $len = 0, return null

### DIFF
--- a/src/protocolbuffers.inc.php
+++ b/src/protocolbuffers.inc.php
@@ -300,6 +300,10 @@ abstract class Protobuf {
 		if ($limit < $len) {
 			throw new Exception('read_bytes(): Unexpected end of stream');
 		}
+		
+		if ($len == 0) {
+			return null;
+		}
 
 		$bytes = fread($fp, $len);
 		if ($bytes === '' && feof($fp)) {


### PR DESCRIPTION
It throws a warning + failes when trying to read 0 byes. Return `null` instead.
Fixes #4
